### PR TITLE
Pin 1.21.11 Sodium stack

### DIFF
--- a/modrinth/1.21.11/index.toml
+++ b/modrinth/1.21.11/index.toml
@@ -287,7 +287,7 @@ metafile = true
 
 [[files]]
 file = "mods/reeses-sodium-options.pw.toml"
-hash = "2785ba5d979ac4f95421a3df7b54ecf2a10e616eb566769388e643a5e91f396b"
+hash = "66ae4a425e4a101670d5c354483013c2dfe031cacdcad2f6719f61764becc742"
 metafile = true
 
 [[files]]
@@ -297,7 +297,7 @@ metafile = true
 
 [[files]]
 file = "mods/scalablelux.pw.toml"
-hash = "f2ee65228e59f2623a3c27a2456ed3aac3fe0e02b96f263976b99ef59cf56d05"
+hash = "45122afe30723fa622917ecd558b22e2bf4c2883ba84fb406c168e12c8d7177e"
 metafile = true
 
 [[files]]
@@ -307,12 +307,12 @@ metafile = true
 
 [[files]]
 file = "mods/sodium-extra.pw.toml"
-hash = "3c5cbbf4755a6a7c0f4f61a243dc6198674f9e2e72faf7d30cc45a3bca3f28a8"
+hash = "f628fb27a4ac42dc6340d7b496747e4a1a4bbf764e8a00854b8cb79581c1ae59"
 metafile = true
 
 [[files]]
 file = "mods/sodium.pw.toml"
-hash = "723a13737a51aa682f385ede7e4bfa925b1dfb435436ab2f69dc25c4be1b2c04"
+hash = "9404aa71aa027cac3e354b8d3e8c05f6fa2defe7ced3d99cbdfbb5a35627c15b"
 metafile = true
 
 [[files]]

--- a/modrinth/1.21.11/mods/reeses-sodium-options.pw.toml
+++ b/modrinth/1.21.11/mods/reeses-sodium-options.pw.toml
@@ -1,13 +1,14 @@
 name = "Reese's Sodium Options"
-filename = "reeses-sodium-options-fabric-2.2.3+mc1.21.11.jar"
+filename = "reeses-sodium-options-fabric-2.2.2+mc1.21.11.jar"
 side = "client"
+pin = true
 
 [download]
-url = "https://cdn.modrinth.com/data/Bh37bMuy/versions/P0MH4cn0/reeses-sodium-options-fabric-2.2.3%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/Bh37bMuy/versions/a0OPChhe/reeses-sodium-options-fabric-2.2.2%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "43f00e8862695c44df5488dd3b49378d62c68f6d6558fb4bc56783a92889104f47aeae973bb30a4e70f51ca83e975f36172df36e4bf8700c88f66183a52d9728"
+hash = "a7f2c12a2613affc8731ac24781d5ae8e3d4502de2463081bdf638a5d75b5308c4a8202b4d444e0effc095a66c8d8401e98cd6e7e7bdf19a00ebeca3e8b7468b"
 
 [update]
 [update.modrinth]
 mod-id = "Bh37bMuy"
-version = "P0MH4cn0"
+version = "a0OPChhe"

--- a/modrinth/1.21.11/mods/scalablelux.pw.toml
+++ b/modrinth/1.21.11/mods/scalablelux.pw.toml
@@ -1,12 +1,14 @@
 name = "ScalableLux"
-filename = "ScalableLux-fabric-0.3.0-alpha.0.3-all.jar.disabled"
+filename = "ScalableLux-0.1.6+fabric.c25518a-all.jar.disabled"
 side = "both"
+pin = true
 
 [download]
-url = "https://cdn.modrinth.com/data/Ps1zyz6x/versions/ju27pK32/ScalableLux-fabric-0.3.0-alpha.0.3-all.jar"
+url = "https://cdn.modrinth.com/data/Ps1zyz6x/versions/PV9KcrYQ/ScalableLux-0.1.6%2Bfabric.c25518a-all.jar"
 hash-format = "sha512"
-hash = "521e1c4abc4193141d5894b686fa5314e89f4b0031aaf8bf59280d562c68b90abd71497634ddde84406c68b892713cefd89e622528a2984b65c0a627ca392f42"
+hash = "729515c1e75cf8d9cd704f12b3487ddb9664cf9928e7b85b12289c8fbbc7ed82d0211e1851375cbd5b385820b4fedbc3f617038fff5e30b302047b0937042ae7"
 
+[update]
 [update.modrinth]
 mod-id = "Ps1zyz6x"
-version = "ju27pK32"
+version = "PV9KcrYQ"

--- a/modrinth/1.21.11/mods/sodium-extra.pw.toml
+++ b/modrinth/1.21.11/mods/sodium-extra.pw.toml
@@ -1,13 +1,14 @@
 name = "Sodium Extra"
-filename = "sodium-extra-fabric-0.9.3+mc1.21.11.jar"
+filename = "sodium-extra-fabric-0.9.1+mc1.21.11.jar"
 side = "client"
+pin = true
 
 [download]
-url = "https://cdn.modrinth.com/data/PtjYWJkn/versions/taHK5pw1/sodium-extra-fabric-0.9.3%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/PtjYWJkn/versions/zmsIDdn6/sodium-extra-fabric-0.9.1%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "a82b6da5431c80d80c2afcebafd3eeefdf547e295593b3f54b499cdc5899d9da7331ea8263f61622a415e97ee11eaf1a20732422e6349add61bc010ada8bf4c8"
+hash = "6fb4228c2466efd5f2a4766f5c29ba31123e75842fdcfd3699f45646abe1ed17418f47d1468066f4e059e6d8f20d583b6d77696e78f3dd8a0af5e041dec84487"
 
 [update]
 [update.modrinth]
 mod-id = "PtjYWJkn"
-version = "taHK5pw1"
+version = "zmsIDdn6"

--- a/modrinth/1.21.11/mods/sodium.pw.toml
+++ b/modrinth/1.21.11/mods/sodium.pw.toml
@@ -1,13 +1,14 @@
 name = "Sodium"
-filename = "sodium-fabric-0.8.13+mc1.21.11.jar"
+filename = "sodium-fabric-0.8.12+mc1.21.11.jar"
 side = "client"
+pin = true
 
 [download]
-url = "https://cdn.modrinth.com/data/AANobbMI/versions/Ny3XyYle/sodium-fabric-0.8.13%2Bmc1.21.11.jar"
+url = "https://cdn.modrinth.com/data/AANobbMI/versions/NFkjnzWE/sodium-fabric-0.8.12%2Bmc1.21.11.jar"
 hash-format = "sha512"
-hash = "6e96ed8e547ea7a8c32273a1152cf02cb26246b3a605c4ed782dc84a52cfbc16d07313c2ea7e1e5e5377784e3e9cbc599b0f2dd139d9fe4c9cbe3381f0dc30f0"
+hash = "17fdb8240670d069e9bb4d00cd3d17afe28ea3f7ea7daf27fd32844f302516e7a889686429db81f2c7b73ad4afce703cac8963a8c3943cfebf45d2c570bd8256"
 
 [update]
 [update.modrinth]
 mod-id = "AANobbMI"
-version = "Ny3XyYle"
+version = "NFkjnzWE"

--- a/modrinth/1.21.11/pack.toml
+++ b/modrinth/1.21.11/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "2164a873e771f764ed80b59a39ae2e237887dcffb4c36138c8630e177a0ba47f"
+hash = "4a063d94d94c9aa336b3241b09778d2e4909ff1997f76609ca68aab1cf690b50"
 
 [versions]
 fabric = "0.19.3"


### PR DESCRIPTION
## Summary
- Pins the 1.21.11 Sodium-side client stack to the last known-good versions.
- Keeps Sodium at 0.8.12 because Sodium 0.8.13 breaks Iris 1.10.7 and no newer Iris exists for Minecraft 1.21.11 yet.
- Pins Sodium Extra, Reese's Sodium Options, and ScalableLux with packwiz `pin = true` so weekly-sync does not partially advance the stack again.

## Validation
- Verified packwiz update keeps the pinned metadata unchanged in a temp copy.
- Full runtime test passed on fork: https://github.com/HermesScorpio/RedstoneToolkit/actions/runs/29360665020
