### PR TITLE
Bump pack version to 0.13.0

### DIFF
--- a/curseforge/1.16.5/pack.toml
+++ b/curseforge/1.16.5/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/curseforge/1.17.1/pack.toml
+++ b/curseforge/1.17.1/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/curseforge/1.18.2/pack.toml
+++ b/curseforge/1.18.2/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/curseforge/1.19.4/pack.toml
+++ b/curseforge/1.19.4/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/curseforge/1.20.6/pack.toml
+++ b/curseforge/1.20.6/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/curseforge/1.21.1/pack.toml
+++ b/curseforge/1.21.1/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]
@@ -13,4 +13,6 @@ fabric = "0.19.3"
 minecraft = "1.21.1"
 
 [options]
-acceptable-game-versions = ["1.21"]
+acceptable-game-versions = [
+    "1.21",
+]

--- a/curseforge/1.21.11/pack.toml
+++ b/curseforge/1.21.11/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/curseforge/26.1.2/pack.toml
+++ b/curseforge/26.1.2/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]
@@ -13,4 +13,6 @@ fabric = "0.19.3"
 minecraft = "26.1.2"
 
 [options]
-acceptable-game-versions = ["26.1"]
+acceptable-game-versions = [
+    "26.1",
+]

--- a/curseforge/26.2.0/pack.toml
+++ b/curseforge/26.2.0/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/curseforge/26.3.0/pack.toml
+++ b/curseforge/26.3.0/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/modrinth/1.16.5/pack.toml
+++ b/modrinth/1.16.5/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/modrinth/1.17.1/pack.toml
+++ b/modrinth/1.17.1/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/modrinth/1.18.2/pack.toml
+++ b/modrinth/1.18.2/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/modrinth/1.19.4/pack.toml
+++ b/modrinth/1.19.4/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/modrinth/1.20.6/pack.toml
+++ b/modrinth/1.20.6/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/modrinth/1.21.1/pack.toml
+++ b/modrinth/1.21.1/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]
@@ -13,4 +13,6 @@ fabric = "0.19.3"
 minecraft = "1.21.1"
 
 [options]
-acceptable-game-versions = ["1.21"]
+acceptable-game-versions = [
+    "1.21",
+]

--- a/modrinth/1.21.11/pack.toml
+++ b/modrinth/1.21.11/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]
@@ -13,4 +13,6 @@ fabric = "0.19.3"
 minecraft = "1.21.11"
 
 [options]
-acceptable-game-versions = ["1.21.10"]
+acceptable-game-versions = [
+    "1.21.10",
+]

--- a/modrinth/26.1.2/pack.toml
+++ b/modrinth/26.1.2/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]
@@ -13,4 +13,6 @@ fabric = "0.19.3"
 minecraft = "26.1.2"
 
 [options]
-acceptable-game-versions = ["26.1"]
+acceptable-game-versions = [
+    "26.1",
+]

--- a/modrinth/26.2.0/pack.toml
+++ b/modrinth/26.2.0/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/modrinth/26.3.0/pack.toml
+++ b/modrinth/26.3.0/pack.toml
@@ -1,6 +1,6 @@
 name = "RedstoneToolkit"
 author = "Scorpio"
-version = "0.12.1"
+version = "0.13.0"
 pack-format = "packwiz:1.1.0"
 
 [index]


### PR DESCRIPTION
## Summary
- Updates all CurseForge and Modrinth pack.toml files to version 0.13.0.

## Validation
- Verified all 20 pack.toml files contain version = "0.13.0".
- Ran git diff --check.
