### PR TITLE
Add IBCarpet to newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ These mods are enabled by default and recommended to the user
 - [Carpet Igny Addition](https://modrinth.com/mod/carpet-igny-addition) – A Carpet extension adding various technical features including bot management rules
 - [Carpet Mod](https://modrinth.com/mod/carpet) - The most important mod for technical Minecraft; it comes with tons of useful features and commands
 - [Carpet TIS Addition](https://modrinth.com/mod/carpet-tis-addition) - Very useful Carpet extension with lots of new rules and tools, in particular for doing stuff in creative mode
+- [IBCarpet](https://modrinth.com/mod/ibcarpet) - A Carpet extension for exaggerating rare item entity RNG outcomes, porting JoaCarpet's insane behavior feature to newer versions
 - [JoaCarpet](https://modrinth.com/mod/joacarpet) - A small Carpet extension with a few useful features for redstone and storage tech
 - [SubTick](https://modrinth.com/mod/subtick) - Allows freezing and stepping through block ticks, fluid ticks, block events, entities, and block entities individually, with HUD visualization and configurable defaults
 - [Yet Another Carpet Addition](https://modrinth.com/mod/yaca) - Adds a lot of useful features, including visualization for scheduled ticks, hopper cooldowns, random ticks, block updates, etc. Provides GUI interfaces for Carpet rule management and hopper counter tracking

--- a/README_CF.md
+++ b/README_CF.md
@@ -32,6 +32,7 @@ These mods are enabled by default and recommended to the user
 - [Carpet Igny Addition](https://modrinth.com/mod/carpet-igny-addition) 鈥?A Carpet extension adding various technical features including bot management rules
 - [Carpet Mod](https://modrinth.com/mod/carpet) - The most important mod for technical Minecraft; it comes with tons of useful features and commands
 - [Carpet TIS Addition](https://modrinth.com/mod/carpet-tis-addition) - Very useful Carpet extension with lots of new rules and tools, in particular for doing stuff in creative mode
+- [IBCarpet](https://modrinth.com/mod/ibcarpet) - A Carpet extension for exaggerating rare item entity RNG outcomes, porting JoaCarpet's insane behavior feature to newer versions
 - [JoaCarpet](https://modrinth.com/mod/joacarpet) - A small Carpet extension with a few useful features for redstone and storage tech
 - [SubTick](https://modrinth.com/mod/subtick) - Allows freezing and stepping through block ticks, fluid ticks, block events, entities, and block entities individually, with HUD visualization and configurable defaults
 - [Yet Another Carpet Addition](https://modrinth.com/mod/yaca) - Adds a lot of useful features, including visualization for scheduled ticks, hopper cooldowns, random ticks, block updates, etc. Provides GUI interfaces for Carpet rule management and hopper counter tracking

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,13 @@
 ## News
 
 - Added newly compatible mods to:
+  - 1.21.11:
+    - IBCarpet
+  - 26.1.2:
+    - IBCarpet
   - 26.2:
     - G4mespeed
+    - IBCarpet
     - Krypton
     - Redstone Multimeter Fabric
 
@@ -23,6 +28,8 @@
   - Fabric API
 - 1.21.1-26.2:
   - Concurrent Chunk Management Engine (Fabric)
+- 1.21.11-26.2:
+  - IBCarpet
 - 26.1.2-26.2:
   - Better Block Entities
   - YetAnotherConfigLib (YACL)

--- a/file_list.yml
+++ b/file_list.yml
@@ -10,7 +10,10 @@ enabled_files:
       26.3.0: "https://github.com/gnembon/fabric-carpet/releases/download/v26.3-beta-2/fabric-carpet-26.3-beta-2%2Bv260709.jar"
   - mr_slug: carpet-tis-addition
     cf_slug: carpet-tis-addition
+  - mr_slug: ibcarpet
+    version: ">1.21.1"
   - mr_slug: joacarpet
+    version: "<=1.21.1"
   - mr_slug: subtick
     name: SubTick
     urls:

--- a/modrinth/1.21.11/index.toml
+++ b/modrinth/1.21.11/index.toml
@@ -161,6 +161,11 @@ hash = "eb90e157646cd2c519fb35d1ebc3c0c1676d970083e142ca083547f28d6ce60c"
 metafile = true
 
 [[files]]
+file = "mods/ibcarpet.pw.toml"
+hash = "114860d720d29c4ee622f84191d821846fa2fb6924e3f0c7cc60f199ef30353f"
+metafile = true
+
+[[files]]
 file = "mods/immediatelyfast.pw.toml"
 hash = "9cb9fbb7431ed58a8bb7bf25d1b9fcc8706fc57400db7acffef06e25971552fa"
 metafile = true

--- a/modrinth/1.21.11/mods/ibcarpet.pw.toml
+++ b/modrinth/1.21.11/mods/ibcarpet.pw.toml
@@ -1,0 +1,13 @@
+name = "IBCarpet"
+filename = "ibcarpet-1.21.11-26.07.17.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/dZhnUIjT/versions/cFdqKDqe/ibcarpet-1.21.11-26.07.17.jar"
+hash-format = "sha512"
+hash = "a7ce0a39f10bde826c281f2cf70b5a9d45531f0e71f4ebf7801d99ab1d3ff0617a2b2fbe8355ad3dfad9af03c6c2bde94c460a28a80b82723f7c0f519720731e"
+
+[update]
+[update.modrinth]
+mod-id = "dZhnUIjT"
+version = "cFdqKDqe"

--- a/modrinth/1.21.11/pack.toml
+++ b/modrinth/1.21.11/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "5fa11fcf3e05c44797a0a2dd3c19a3d1cc3beec53e10e71460416b722847aef5"
+hash = "3a912ccba9527c65623aa175ce370bbde00b256b6b7e24224b6dc66dba80f60f"
 
 [versions]
 fabric = "0.19.3"

--- a/modrinth/26.1.2/index.toml
+++ b/modrinth/26.1.2/index.toml
@@ -156,6 +156,11 @@ hash = "2bab0998d1b23069194b242a8bcc5afd2fbbc4047218fdf1d997316fe8cd8221"
 metafile = true
 
 [[files]]
+file = "mods/ibcarpet.pw.toml"
+hash = "13f60da958327d8a39ffd7a0ef8b24152173019c3469887cf60306e7c4be55be"
+metafile = true
+
+[[files]]
 file = "mods/immediatelyfast.pw.toml"
 hash = "59d8a7808f69deae5bc1c17ed2db6c28cb231398681f6f7902ae7e92da229e1a"
 metafile = true

--- a/modrinth/26.1.2/mods/ibcarpet.pw.toml
+++ b/modrinth/26.1.2/mods/ibcarpet.pw.toml
@@ -1,0 +1,13 @@
+name = "IBCarpet"
+filename = "ibcarpet-26.1.2-26.07.17.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/dZhnUIjT/versions/9IRmbx90/ibcarpet-26.1.2-26.07.17.jar"
+hash-format = "sha512"
+hash = "11e0e140c452002bc9fb0f18cbb8e2a28119c8906b3eb0f82761b0a49ed845e95182a70a8126040a1877348a9457f0179efbc76efbaf4e2313024952e9784450"
+
+[update]
+[update.modrinth]
+mod-id = "dZhnUIjT"
+version = "9IRmbx90"

--- a/modrinth/26.1.2/pack.toml
+++ b/modrinth/26.1.2/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "4f9b23664bd6d4674c143b41607c21a19fe4320c7fccdcd7f16ac79181dfa6d9"
+hash = "601bf90e5c5b946b28a0312d0e0d3e87226b704784dfb03f67047076fce2a3da"
 
 [versions]
 fabric = "0.19.3"

--- a/modrinth/26.2.0/index.toml
+++ b/modrinth/26.2.0/index.toml
@@ -136,6 +136,11 @@ hash = "2bab0998d1b23069194b242a8bcc5afd2fbbc4047218fdf1d997316fe8cd8221"
 metafile = true
 
 [[files]]
+file = "mods/ibcarpet.pw.toml"
+hash = "b29dbe43ab1fd3077f76893b847196cc407cd57d486995b8bdba254553e353d8"
+metafile = true
+
+[[files]]
 file = "mods/immediatelyfast.pw.toml"
 hash = "4558d459a64d360ef8954016a272f690b45e74fe8f078388a5a6329e5fa973f6"
 metafile = true

--- a/modrinth/26.2.0/mods/ibcarpet.pw.toml
+++ b/modrinth/26.2.0/mods/ibcarpet.pw.toml
@@ -1,0 +1,13 @@
+name = "IBCarpet"
+filename = "ibcarpet-26.2-26.07.16.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/dZhnUIjT/versions/kT3CS8ld/ibcarpet-26.2-26.07.16.jar"
+hash-format = "sha512"
+hash = "03865900a385ad9913d5240ed7454f3d9a5c06ad0f7b6fac33757914e98d31577f46b453533358bf1d9755e3955756a81cfef796bc1733de86a599a2030c920f"
+
+[update]
+[update.modrinth]
+mod-id = "dZhnUIjT"
+version = "kT3CS8ld"

--- a/modrinth/26.2.0/pack.toml
+++ b/modrinth/26.2.0/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f8ab04d4123d751f8c497c5203c1f67eb4571e11abc72ccb6a51021253cdfb39"
+hash = "181a70e296d8dfbf31a1e500d938c4d374f15a89d009542c219b1fdbda5b81c8"
 
 [versions]
 fabric = "0.19.3"


### PR DESCRIPTION
## Summary
- Add IBCarpet to take over JoaCarpet's role on versions after 1.21.1.
- Install IBCarpet via Modrinth for 1.21.11, 26.1.2, and 26.2.
- Document IBCarpet in the README Carpet sections.
- Regenerate the changelog from the latest release base.

## Validation
- Synced local main with origin/main before changes.
- Ran `python -m script install --platform all --match ">1.21.1"`.
- Install exited `0`.
- Verified IBCarpet installed for Modrinth 1.21.11, 26.1.2, and 26.2.
- Verified JoaCarpet remains only through 1.21.1.
