### PR TITLE
Run weekly sync install with reinstall

### DIFF
--- a/.github/workflows/weekly-sync.yml
+++ b/.github/workflows/weekly-sync.yml
@@ -48,7 +48,7 @@ jobs:
         timeout-minutes: 20
         run: |
           set +e
-          python -m script install
+          python -m script install --reinstall
           INSTALL_EXIT=$?
           set -e
           if [ $INSTALL_EXIT -ne 0 ]; then


### PR DESCRIPTION
## Summary
- Run weekly sync's install step with `--reinstall`
- Refresh cross-platform metadata instead of only filling missing files

## Validation
- Verified `script install --help` includes `--reinstall`
- Diff is limited to `.github/workflows/weekly-sync.yml`
